### PR TITLE
Fix handling of windows names with a suffix in brackets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,8 +97,17 @@ class Timezone {
     }
 
     // 2. Try windows mapping names
-    // Notice that here we remove the "(UTC+XX:00)" prefix from the timezone name
-    const ianaFromMs = windowsZones[tzName.replace(/\(.*\)\s*/gm, "").trim()];
+    // First try exact match
+    let ianaFromMs = windowsZones[tzName.trim()];
+    if (ianaFromMs) {
+      this.validated_ = true;
+      return ianaFromMs;
+    }
+
+    // If no match, try removing only prefix within brackets
+    // This becuase sometimes old Microsoft services return the timezone with a prefix like "(UTC+XX:00)"
+    // which is not part of the Windows zone name.
+    ianaFromMs = windowsZones[tzName.replace(/^\([^)]+\)\s*/gm, "").trim()];
     if (ianaFromMs) {
       this.validated_ = true;
       return ianaFromMs;

--- a/tests/timezone.spec.ts
+++ b/tests/timezone.spec.ts
@@ -75,6 +75,13 @@ describe("Timezone general", () => {
     expect(tz.ianaName).toEqual("Europe/Berlin");
   });
 
+  it("maps 'Central Standard Time (Mexico)' zone ID to America/Mexico_City", async () => {
+    const msTzName = "Central Standard Time (Mexico)";
+    const tz = new TimezoneService.Timezone(msTzName);
+    expect(tz.validated).toBeTruthy();
+    expect(tz.ianaName).toEqual("America/Mexico_City");
+  });
+
   it("maps offsets to IANA names", async () => {
     expect(new TimezoneService.Timezone("GMT+0100").ianaName).toEqual(
       "Etc/GMT-1"


### PR DESCRIPTION
The timezone `Central Standard Time (Mexico)` was incorrectly mapped to `America/Chicago`